### PR TITLE
Changed dependency from edge:meteor-server-deps@0.1.2 to peerlibary:s…

### DIFF
--- a/package.js
+++ b/package.js
@@ -11,7 +11,7 @@ Package.on_use(function(api) {
 		'coffeescript',
 		'tracker',
 		'underscore',
-		'edgee:meteor-server-deps@0.1.2',
+		'peerlibrary:server-autorun',
 		'accounts-base'
 	], 'server');
 


### PR DESCRIPTION
…erver-autorun to solve onStop error causing using Meteor 1.2.
